### PR TITLE
Learning Rate Finder

### DIFF
--- a/dl_framework/callbacks.py
+++ b/dl_framework/callbacks.py
@@ -146,22 +146,24 @@ class Recorder_lr_find(Callback):
         self.lrs.append(self.opt.hypers[-1]['lr'])
         self.losses.append(self.loss.detach().cpu())
 
-    def plot(self, skip_last=0):
+    def plot(self, skip_last=0, save=False):
         losses = [o.item() for o in self.losses]
         n = len(losses)-skip_last
         plt.plot(self.lrs[:n], losses[:n])
         plt.xscale('log')
         plt.xlabel(r'learning rate')
         plt.ylabel(r'loss')
-        plt.show()
+        if save is False:
+            plt.show()
 
 
 class LR_Find(Callback):
     _order = 1
 
-    def __init__(self, max_iter=400, min_lr=1e-6, max_lr=0.1):
+    def __init__(self, max_iter=100, min_lr=1e-6, max_lr=10):
         """
         max_iter should be slightly bigger than the number of batches.
+        Only this way maximum and minimum learning rate are set.
         """
         self.max_iter = max_iter
         self.min_lr = min_lr

--- a/dl_framework/callbacks.py
+++ b/dl_framework/callbacks.py
@@ -125,6 +125,7 @@ class Recorder(Callback):
         n = len(losses)-skip_last
         plt.xscale('log')
         plt.plot(self.lrs[:n], losses[:n])
+        plt.show()
 
 
 class LR_Find(Callback):

--- a/dl_framework/callbacks.py
+++ b/dl_framework/callbacks.py
@@ -131,6 +131,11 @@ class Recorder(Callback):
 
 
 class Recorder_lr_find(Callback):
+    """
+    Recorder class for the lr_find. Main difference between the recorder
+    and this class is that the loss is appended after each batch and not
+    after each epoch.
+    """
     def begin_fit(self):
         self.lrs = []
         self.losses = []
@@ -140,12 +145,6 @@ class Recorder_lr_find(Callback):
             return
         self.lrs.append(self.opt.hypers[-1]['lr'])
         self.losses.append(self.loss.detach().cpu())
-
-    def plot_lr(self):
-        plt.plot(self.lrs)
-
-    def plot_loss(self):
-        plt.plot(self.losses)
 
     def plot(self, skip_last=0):
         losses = [o.item() for o in self.losses]
@@ -161,6 +160,9 @@ class LR_Find(Callback):
     _order = 1
 
     def __init__(self, max_iter=400, min_lr=1e-6, max_lr=0.1):
+        """
+        max_iter should be slightly bigger than the number of batches.
+        """
         self.max_iter = max_iter
         self.min_lr = min_lr
         self.max_lr = max_lr

--- a/mnist_cnn/Makefile
+++ b/mnist_cnn/Makefile
@@ -27,6 +27,7 @@ mnist_samp_valid: ./data/mnist_samp_valid.h5
 calc_normalization: ./data/normalization_factors.csv
 cnn_training: ./training_done
 input_plot: ./data/plots/input_done
+find_lr: ./lr_find
 
 #########################################################
 #	Tasks
@@ -77,6 +78,15 @@ input_plot: ./data/plots/input_done
 		-pretrained False ./models/test.model\
 		-inspection True
 		touch ./training_done
+
+./lr_find:
+		mkdir -p models/
+		python find_lr.py ./data/mnist_samp_train.h5\
+		./data/mnist_samp_valid.h5 ./models/test_pred.model\
+		cnn ./data/normalization_factors.csv\
+		100 1e-3 -log False\
+		-pretrained False ./models/test.model\
+		-inspection True
 
 ./data/plots/input_done:
 		mkdir -p data/

--- a/mnist_cnn/Makefile
+++ b/mnist_cnn/Makefile
@@ -83,10 +83,9 @@ find_lr: ./lr_find
 		mkdir -p models/
 		python find_lr.py ./data/mnist_samp_train.h5\
 		./data/mnist_samp_valid.h5 ./models/test_pred.model\
-		cnn ./data/normalization_factors.csv\
-		100 1e-3 -log False\
+		cnn ./data/normalization_factors.csv -log False\
 		-pretrained False ./models/test.model\
-		-inspection True
+		-save False
 
 ./data/plots/input_done:
 		mkdir -p data/

--- a/mnist_cnn/find_lr.py
+++ b/mnist_cnn/find_lr.py
@@ -8,7 +8,7 @@ from dl_framework.callbacks import (
     AvgStatsCallback,
     BatchTransformXCallback,
     CudaCallback,
-    Recorder,
+    Recorder_lr_find,
     SaveCallback,
     normalize_tfm,
     view_tfm,
@@ -93,9 +93,9 @@ def main(
     # Define callback functions
     cbfs = [
         LR_Find,
-        Recorder,
+        Recorder_lr_find,
         # test for use of multiple Metrics or Loss functions
-        partial(AvgStatsCallback, metrics=[nn.MSELoss(), nn.L1Loss()]),
+        # partial(AvgStatsCallback, metrics=[nn.MSELoss(), nn.L1Loss()]),
         CudaCallback,
         partial(BatchTransformXCallback, norm),
         partial(BatchTransformXCallback, mnist_view),
@@ -112,16 +112,8 @@ def main(
     learn = get_learner(
         data, arch, 1e-3, opt_func=adam_opt, cb_funcs=cbfs,
     )
-
-    # use pre-trained model if asked
-    if pretrained is True:
-        # Load model
-        load_pre_model(learn.model, pretrained_model)
-
-    # Print model architecture
-    print(learn.model, "\n")
     learn.fit(2)
-    learn.recorder.plot()
+    learn.recorder_lr_find.plot(skip_last=5)
 
 
 if __name__ == "__main__":

--- a/mnist_cnn/find_lr.py
+++ b/mnist_cnn/find_lr.py
@@ -1,0 +1,128 @@
+from functools import partial
+
+import click
+
+import dl_framework.architectures as architecture
+import torch.nn as nn
+from dl_framework.callbacks import (
+    AvgStatsCallback,
+    BatchTransformXCallback,
+    CudaCallback,
+    Recorder,
+    SaveCallback,
+    normalize_tfm,
+    view_tfm,
+    LR_Find,
+)
+from dl_framework.learner import get_learner
+from dl_framework.model import load_pre_model
+from dl_framework.optimizer import (
+    AverageGrad,
+    AverageSqrGrad,
+    StatefulOptimizer,
+    StepCount,
+    adam_step,
+    weight_decay,
+)
+from dl_framework.param_scheduling import sched_no
+from mnist_cnn.utils import get_h5_data
+from preprocessing import DataBunch, get_dls, prepare_dataset
+
+
+@click.command()
+@click.argument("train_path", type=click.Path(exists=True, dir_okay=True))
+@click.argument("valid_path", type=click.Path(exists=True, dir_okay=True))
+@click.argument("model_path", type=click.Path(exists=False, dir_okay=True))
+@click.argument("arch", type=str)
+@click.argument("norm_path", type=click.Path(exists=False, dir_okay=True))
+@click.argument("num_epochs", type=int)
+@click.argument("lr", type=float)
+@click.argument(
+    "pretrained_model", type=click.Path(exists=True, dir_okay=True), required=False
+)
+@click.option("-log", type=bool, required=False, help="use of logarith")
+@click.option(
+    "-pretrained", type=bool, required=False, help="use of a pretrained model"
+)
+@click.option("-inspection", type=bool, required=False, help="make an inspection plot")
+def main(
+    train_path,
+    valid_path,
+    model_path,
+    arch,
+    norm_path,
+    num_epochs,
+    lr,
+    log=True,
+    pretrained=False,
+    pretrained_model=None,
+    inspection=False,
+):
+    """
+    Train the neural network with existing training and validation data.
+    TRAIN_PATH is the path to the training data\n
+    VALID_PATH ist the path to the validation data\n
+    MODEL_PATH is the Path to which the model is saved\n
+    ARCH is the name of the architecture which is used\n
+    NORM_PATH is the path to the normalisation factors\n
+    NUM_EPOCHS is the number of epochs\n
+    LR is the learning rate\n
+    PRETRAINED_MODEL is the path to a pretrained model, which is
+                     loaded at the beginning of the training\n
+    """
+    # Load data
+    x_train, y_train = get_h5_data(train_path, columns=["x_train", "y_train"])
+    x_valid, y_valid = get_h5_data(valid_path, columns=["x_valid", "y_valid"])
+
+    # Create train and valid datasets
+    train_ds, valid_ds = prepare_dataset(x_train, y_train, x_valid, y_valid, log=log)
+
+    # Create databunch with defined batchsize
+    bs = 256
+    data = DataBunch(*get_dls(train_ds, valid_ds, bs), c=train_ds.c)
+
+    # Define model
+    arch = getattr(architecture, arch)()
+
+    # Define resize for mnist data
+    mnist_view = view_tfm(2, 64, 64)
+
+    # make normalisation
+    norm = normalize_tfm(norm_path)
+
+    # Define callback functions
+    cbfs = [
+        LR_Find,
+        Recorder,
+        # test for use of multiple Metrics or Loss functions
+        partial(AvgStatsCallback, metrics=[nn.MSELoss(), nn.L1Loss()]),
+        CudaCallback,
+        partial(BatchTransformXCallback, norm),
+        partial(BatchTransformXCallback, mnist_view),
+        SaveCallback,
+    ]
+
+    # Define optimiser function
+    adam_opt = partial(
+        StatefulOptimizer,
+        steppers=[adam_step, weight_decay],
+        stats=[AverageGrad(dampening=True), AverageSqrGrad(), StepCount()],
+    )
+    # Combine model and data in learner
+    learn = get_learner(
+        data, arch, 1e-3, opt_func=adam_opt, cb_funcs=cbfs,
+    )
+
+    # use pre-trained model if asked
+    if pretrained is True:
+        # Load model
+        load_pre_model(learn.model, pretrained_model)
+
+    # Print model architecture
+    print(learn.model, "\n")
+    learn.fit(2)
+    learn.recorder.plot()
+
+
+if __name__ == "__main__":
+    main()

--- a/mnist_cnn/find_lr.py
+++ b/mnist_cnn/find_lr.py
@@ -59,8 +59,6 @@ def main(
     MODEL_PATH is the Path to which the model is saved\n
     ARCH is the name of the architecture which is used\n
     NORM_PATH is the path to the normalisation factors\n
-    NUM_EPOCHS is the number of epochs\n
-    LR is the learning rate\n
     PRETRAINED_MODEL is the path to a pretrained model, which is
                      loaded at the beginning of the training\n
     """
@@ -74,6 +72,9 @@ def main(
     # Create databunch with defined batchsize
     bs = 256
     data = DataBunch(*get_dls(train_ds, valid_ds, bs), c=train_ds.c)
+
+    # First guess for max_iter
+    print("\nTotal number of batches ~ ", data.train_ds.x.size(0)*2//bs)
 
     # Define model
     arch = getattr(architecture, arch)()

--- a/mnist_cnn/inspection.py
+++ b/mnist_cnn/inspection.py
@@ -67,3 +67,10 @@ def plot_loss(learn, model_path):
     print('\nPlotting Loss for: {}\n'.format(name_model))
     learn.recorder.plot_loss()
     plt.savefig('./models/loss.pdf', bbox_inches='tight', pad_inches=0.01)
+
+
+def plot_lr_loss(learn, model_path, skip_last):
+    name_model = model_path.split("/")[-1].split(".")[0]
+    print('\nPlotting Lr vs Loss for: {}\n'.format(name_model))
+    learn.recorder_lr_find.plot(skip_last, save=True)
+    plt.savefig('./models/lr_loss.pdf', bbox_inches='tight', pad_inches=0.01)


### PR DESCRIPTION
Implemented a new script for a learning rate finder.

To get a first guess for the magnitude of the `max_iter` parameter, which is critical for the use of minimal and maximal learning rate, `print(data.train_ds.x.size(0)*2//bs)` gets printed out, which, in my opinion, should be roughly the total number of batches used during training. Based on that, `max_iter` should be slightly bigger than the total number of batches. If that is the case, a resulting plot should look like this [plot](https://github.com/Kevin2/radionets/files/4077280/lr_loss.pdf).
