### PR TITLE
Model and loss get saved in eponymous folder

### DIFF
--- a/mnist_cnn/Makefile
+++ b/mnist_cnn/Makefile
@@ -70,11 +70,11 @@ find_lr: ./lr_find
 		data/normalization_factors.csv
 
 ./training_done:
-		mkdir -p models/
+		mkdir -p models/test_pred
 		python train_cnn.py ./data/mnist_samp_train.h5\
-		./data/mnist_samp_valid.h5 ./models/test_pred.model\
+		./data/mnist_samp_valid.h5 ./models/test_pred/test_pred.model\
 		cnn ./data/normalization_factors.csv\
-		150 1e-3 -log False\
+		2 1e-3 -log False\
 		-pretrained False ./models/test.model\
 		-inspection True
 		touch ./training_done

--- a/mnist_cnn/inspection.py
+++ b/mnist_cnn/inspection.py
@@ -64,9 +64,10 @@ def test_initialization(dl, model, layer):
 
 def plot_loss(learn, model_path):
     name_model = model_path.split("/")[-1].split(".")[0]
+    save_path = model_path.split('.model')[0]
     print('\nPlotting Loss for: {}\n'.format(name_model))
     learn.recorder.plot_loss()
-    plt.savefig('./models/loss.pdf', bbox_inches='tight', pad_inches=0.01)
+    plt.savefig('{}_loss.pdf'.format(save_path), bbox_inches='tight', pad_inches=0.01)
 
 
 def plot_lr_loss(learn, model_path, skip_last):


### PR DESCRIPTION
Small, quick change for better overview over the saved models. Now every model gets saved in an eponymous folder along with the loss that gets plotted.