### PR TITLE
Fix dynamic range computation

### DIFF
--- a/gaussian_sources/inspection.py
+++ b/gaussian_sources/inspection.py
@@ -401,52 +401,45 @@ def compute_dr(i, img, sensitivity):
     mode
         mode for following computations
     """
-    # oben links
+    # upper left
     rms1 = compute_rms(img, "rms1", 10)
-    # oben rechts
+    # upper right
     rms2 = compute_rms(img, "rms2", 10)
-    # unten links
+    # down left
     rms3 = compute_rms(img, "rms3", 10)
-    # unten rechts
+    # down right
     rms4 = compute_rms(img, "rms4", 10)
 
     if rms1 > sensitivity:
         if rms4 > sensitivity:
-            print("Bild {}: Oben links und unten rechts zu groß.".format(i))
+            print("Image {}: RMS exceeds upper left and down right.".format(i))
             mode = "rms1+4"
             rms = rms_comp(img, mode)
-            # print(rms2, rms3)
         else:
-            print("Bild {}: Oben links zu groß".format(i))
-            # print(rms2, rms3, rms4)
+            print("Image {}: RMS exceeds upper left".format(i))
             mode = "rms1"
             rms = rms_comp(img, mode)
     elif rms2 > sensitivity:
         if rms3 > sensitivity:
-            print("Bild {}: Oben rechts und unten links zu groß.".format(i))
-            # print(rms1, rms4)
+            print("Image {}: RMS exceeds upper right and down left.".format(i))
             mode = "rms2+3"
             rms = rms_comp(img, mode)
         else:
-            print("Bild {}: oben rechts zu groß".format(i))
-            # print(rms1, rms3, rms4)
+            print("Image {}: RMS exceeds upper right".format(i))
             mode = "rms2"
             rms = rms_comp(img, mode)
     elif rms3 > sensitivity:
-        print("Bild {}: Unten links zu groß".format(i))
-        # print(rms1, rms2, rms4)
+        print("Image {}: RMS exceeds down left".format(i))
         mode = "rms3"
         rms = rms_comp(img, mode)
     elif rms4 > sensitivity:
-        print("Bild {}: Unten rechts zu groß".format(i))
-        # print(rms1, rms2, rms3)
+        print("Image {}: RMS exceeds down right".format(i))
         mode = "rms4"
         rms = rms_comp(img, mode)
     else:
-        # print(rms1, rms2, rms3, rms4)
         mode = None
         rms = rms_comp(img, mode)
-    # print(rms1, rms2, rms3, rms4)
+
     dynamic_range = img.max() / rms
     return dynamic_range, mode
 

--- a/gaussian_sources/inspection.py
+++ b/gaussian_sources/inspection.py
@@ -276,7 +276,7 @@ def visualize_fft(i, real_pred, imag_pred, real_truth, imag_truth, amp_phase, ou
     return np.abs(ifft_pred), np.abs(ifft_truth)
 
 
-def plot_difference(i, img_pred, img_truth, out_path):
+def plot_difference(i, img_pred, img_truth, sensitivity, out_path):
     """Create a subplot with the prediction, the truth and the difference.
     Also computes the dynamic range for the prediction and the truth. Last,
     calculates the quotient between these two values.
@@ -303,15 +303,15 @@ def plot_difference(i, img_pred, img_truth, out_path):
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(16, 12))
 
     # dr_pred = compute_dr(img_pred)
-    dr_truth, mode = compute_dr(img_truth)
+    dr_truth, mode = compute_dr(img_truth, sensitivity)
     dr_pred = compute_dr_pred(img_pred, mode)
     dynamic_range = dr_pred / dr_truth
 
     im1 = ax1.imshow(img_pred)
-    plot_off_regions(ax1)
+    plot_off_regions(ax1, mode)
 
     im2 = ax2.imshow(img_truth)
-    plot_off_regions(ax2)
+    plot_off_regions(ax2, mode)
 
     im3 = ax3.imshow(np.abs(img_pred - img_truth))
 
@@ -330,7 +330,7 @@ def plot_difference(i, img_pred, img_truth, out_path):
     return dynamic_range
 
 
-def plot_off_regions(ax):
+def plot_off_regions(ax, mode):
     """Plot the off regions for the computation of the dynamic range.
 
     Parameters
@@ -338,13 +338,36 @@ def plot_off_regions(ax):
     ax : axis object
         current axis
     """
-    ax.axvspan(0, 9, ymin=0.844, ymax=0.99, color="red", fill=False, label="Off")
-    ax.axvspan(0, 9, ymax=0.156, ymin=0.01, color="red", fill=False)
-    ax.axvspan(53, 62, ymin=0.844, ymax=0.99, color="red", fill=False)
-    ax.axvspan(53, 62, ymax=0.156, ymin=0.01, color="red", fill=False)
+    if mode == "rms1":
+        ax.axvspan(0, 12, ymax=13/63, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(50, 62, ymin=1-13/63, ymax=0.99, color="red", fill=False)
+        ax.axvspan(50, 62, ymax=13/63, ymin=0.01, color="red", fill=False)
+    elif mode == "rms2":
+        ax.axvspan(0, 12, ymax=13/63, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(0, 12, ymax=1-13/63, ymin=0.99, color="red", fill=False)
+        ax.axvspan(50, 62, ymax=13/63, ymin=0.01, color="red", fill=False)
+    elif mode == "rms3":
+        ax.axvspan(0, 12, ymax=1-13/63, ymin=0.99, color="red", fill=False, label="Off")
+        ax.axvspan(50, 62, ymax=1-13/63, ymin=0.99, color="red", fill=False)
+        ax.axvspan(50, 62, ymax=13/63, ymin=0.01, color="red", fill=False)
+    elif mode == "rms4":
+        ax.axvspan(0, 12, ymax=13/63, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(0, 12, ymax=1-13/63, ymin=0.99, color="red", fill=False)
+        ax.axvspan(50, 62, ymax=1-13/63, ymin=0.99, color="red", fill=False)
+    elif mode == "rms1+4":
+        ax.axvspan(0, 19, ymax=20/63, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(43, 62, ymax=1-20/63, ymin=0.99, color="red", fill=False)
+    elif mode == "rms2+3":
+        ax.axvspan(0, 19, ymax=1-20/63, ymin=0.99, color="red", fill=False, label="Off")
+        ax.axvspan(43, 62, ymax=20/63, ymin=0.01, color="red", fill=False)
+    elif mode is None:
+        ax.axvspan(0, 9, ymin=1-10/63, ymax=0.99, color="red", fill=False, label="Off")
+        ax.axvspan(0, 9, ymax=10/63, ymin=0.01, color="red", fill=False)
+        ax.axvspan(53, 62, ymin=1-10/63, ymax=0.99, color="red", fill=False)
+        ax.axvspan(53, 62, ymax=10/63, ymin=0.01, color="red", fill=False)
 
 
-def compute_dr(img):
+def compute_dr(img, sensitivity):
     """Calculate the dynamic range of the given image.
 
     Parameters
@@ -366,7 +389,6 @@ def compute_dr(img):
     # unten rechts
     rms4 = compute_rms(img, "rms4", 10)
 
-    sensitivity = 1e-7
     if rms1 > sensitivity:
         if rms4 > sensitivity:
             print("Oben links und unten rechts zu groß.")

--- a/gaussian_sources/inspection.py
+++ b/gaussian_sources/inspection.py
@@ -307,15 +307,26 @@ def plot_difference(i, img_pred, img_truth, sensitivity, out_path):
 
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(16, 12))
 
-    dr_truth, mode = compute_dr(i, img_truth, sensitivity)
-    dr_pred = compute_dr_pred(img_pred, mode)
+    img_size = img_pred.shape[0]
+    if img_size == 63:
+        # num_tree for 3 off regions, num_two for 2 off regions and so on
+        num_three = 13
+        num_two = 20
+        num_four = 10
+    elif img_size == 127:
+        num_three = 60
+        num_two = 50
+        num_four = 40
+    num = [num_three, num_two, num_four]
+    dr_truth, mode = compute_dr(i, img_truth, sensitivity, num)
+    dr_pred = compute_dr_pred(img_pred, mode, num)
     dynamic_range = dr_pred / dr_truth
 
     im1 = ax1.imshow(img_pred)
-    plot_off_regions(ax1, mode)
+    plot_off_regions(ax1, mode, img_size, num)
 
     im2 = ax2.imshow(img_truth)
-    plot_off_regions(ax2, mode)
+    plot_off_regions(ax2, mode, img_size, num)
 
     im3 = ax3.imshow(np.abs(img_pred - img_truth))
 
@@ -334,7 +345,7 @@ def plot_difference(i, img_pred, img_truth, sensitivity, out_path):
     return dynamic_range
 
 
-def plot_off_regions(ax, mode):
+def plot_off_regions(ax, mode, img_size, num):
     """Plot the off regions for the computation of the dynamic range.
     Adjust the plotted off regions according to the mode.
 
@@ -344,43 +355,48 @@ def plot_off_regions(ax, mode):
         current axis
     mode : str
         current mode
+    img_size : int
+        current image size
+    num : list
+        side length of quadratic off region
     """
+    num_three, num_two, num_four = num[0], num[1], num[2]
     if mode == "rms1":
-        ax.axvspan(0, 12, ymax=13 / 63, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(50, 62, ymin=1 - 13 / 63, ymax=0.99, color="red", fill=False)
-        ax.axvspan(50, 62, ymax=13 / 63, ymin=0.01, color="red", fill=False)
+        ax.axvspan(0, num_three-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(img_size-num_three, img_size-1, ymin=1 - num_three / img_size, ymax=0.99, color="red", fill=False)
+        ax.axvspan(img_size-num_three, img_size-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False)
     elif mode == "rms2":
-        ax.axvspan(0, 12, ymax=13 / 63, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(0, 12, ymax=1 - 13 / 63, ymin=0.99, color="red", fill=False)
-        ax.axvspan(50, 62, ymax=13 / 63, ymin=0.01, color="red", fill=False)
+        ax.axvspan(0, num_three-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(0, num_three-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
+        ax.axvspan(img_size-num_three, img_size-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False)
     elif mode == "rms3":
         ax.axvspan(
-            0, 12, ymax=1 - 13 / 63, ymin=0.99, color="red", fill=False, label="Off"
+            0, num_three-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False, label="Off"
         )
-        ax.axvspan(50, 62, ymax=1 - 13 / 63, ymin=0.99, color="red", fill=False)
-        ax.axvspan(50, 62, ymax=13 / 63, ymin=0.01, color="red", fill=False)
+        ax.axvspan(img_size-num_three, img_size-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
+        ax.axvspan(img_size-num_three, img_size-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False)
     elif mode == "rms4":
-        ax.axvspan(0, 12, ymax=13 / 63, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(0, 12, ymax=1 - 13 / 63, ymin=0.99, color="red", fill=False)
-        ax.axvspan(50, 62, ymax=1 - 13 / 63, ymin=0.99, color="red", fill=False)
+        ax.axvspan(0, num_three-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(0, num_three-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
+        ax.axvspan(img_size-num_three, img_size-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
     elif mode == "rms1+4":
-        ax.axvspan(0, 19, ymax=20 / 63, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(43, 62, ymax=1 - 20 / 63, ymin=0.99, color="red", fill=False)
+        ax.axvspan(0, num_two-1, ymax=num_two / img_size, ymin=0.01, color="red", fill=False, label="Off")
+        ax.axvspan(img_size-num_two, img_size-1, ymax=1 - num_two / img_size, ymin=0.99, color="red", fill=False)
     elif mode == "rms2+3":
         ax.axvspan(
-            0, 19, ymax=1 - 20 / 63, ymin=0.99, color="red", fill=False, label="Off"
+            0, num_two-1, ymax=1 - num_two / img_size, ymin=0.99, color="red", fill=False, label="Off"
         )
-        ax.axvspan(43, 62, ymax=20 / 63, ymin=0.01, color="red", fill=False)
+        ax.axvspan(img_size-num_two, img_size-1, ymax=num_two / img_size, ymin=0.01, color="red", fill=False)
     elif mode is None:
         ax.axvspan(
-            0, 9, ymin=1 - 10 / 63, ymax=0.99, color="red", fill=False, label="Off"
+            0, num_four-1, ymin=1 - num_four / img_size, ymax=0.99, color="red", fill=False, label="Off"
         )
-        ax.axvspan(0, 9, ymax=10 / 63, ymin=0.01, color="red", fill=False)
-        ax.axvspan(53, 62, ymin=1 - 10 / 63, ymax=0.99, color="red", fill=False)
-        ax.axvspan(53, 62, ymax=10 / 63, ymin=0.01, color="red", fill=False)
+        ax.axvspan(0, num_four-1, ymax=num_four / img_size, ymin=0.01, color="red", fill=False)
+        ax.axvspan(img_size-num_four, img_size-1, ymin=1 - num_four / img_size, ymax=0.99, color="red", fill=False)
+        ax.axvspan(img_size-num_four, img_size-1, ymax=num_four / img_size, ymin=0.01, color="red", fill=False)
 
 
-def compute_dr(i, img, sensitivity):
+def compute_dr(i, img, sensitivity, num):
     """Compute the dynamic range for the true image. Also checks if one region
     exceeds the sensitivity. If so, mode is set accordingly for the following
     computations, including the predicted image.
@@ -393,6 +409,8 @@ def compute_dr(i, img, sensitivity):
         current image
     sensitivity : float
         upper limit for RMS value
+    num : list
+        side length of quadratic off region
 
     Returns
     -------
@@ -401,50 +419,51 @@ def compute_dr(i, img, sensitivity):
     mode
         mode for following computations
     """
+    num_four = num[2]
     # upper left
-    rms1 = compute_rms(img, "rms1", 10)
+    rms1 = compute_rms(img, "rms1", num_four)
     # upper right
-    rms2 = compute_rms(img, "rms2", 10)
+    rms2 = compute_rms(img, "rms2", num_four)
     # down left
-    rms3 = compute_rms(img, "rms3", 10)
+    rms3 = compute_rms(img, "rms3", num_four)
     # down right
-    rms4 = compute_rms(img, "rms4", 10)
+    rms4 = compute_rms(img, "rms4", num_four)
 
     if rms1 > sensitivity:
         if rms4 > sensitivity:
             print("Image {}: RMS exceeds upper left and down right.".format(i))
             mode = "rms1+4"
-            rms = rms_comp(img, mode)
+            rms = rms_comp(img, mode, num)
         else:
             print("Image {}: RMS exceeds upper left".format(i))
             mode = "rms1"
-            rms = rms_comp(img, mode)
+            rms = rms_comp(img, mode, num)
     elif rms2 > sensitivity:
         if rms3 > sensitivity:
             print("Image {}: RMS exceeds upper right and down left.".format(i))
             mode = "rms2+3"
-            rms = rms_comp(img, mode)
+            rms = rms_comp(img, mode, num)
         else:
             print("Image {}: RMS exceeds upper right".format(i))
             mode = "rms2"
-            rms = rms_comp(img, mode)
+            rms = rms_comp(img, mode, num)
     elif rms3 > sensitivity:
         print("Image {}: RMS exceeds down left".format(i))
         mode = "rms3"
-        rms = rms_comp(img, mode)
+        rms = rms_comp(img, mode, num)
     elif rms4 > sensitivity:
         print("Image {}: RMS exceeds down right".format(i))
         mode = "rms4"
-        rms = rms_comp(img, mode)
+        rms = rms_comp(img, mode, num)
     else:
         mode = None
-        rms = rms_comp(img, mode)
+        rms = rms_comp(img, mode, num)
 
     dynamic_range = img.max() / rms
     return dynamic_range, mode
 
 
-def compute_dr_pred(img, mode):
+def compute_dr_pred(img, mode, num):
     """Compute the dynamic range on the predicted image according to the mode set
     by compute_dr.
 
@@ -454,6 +473,8 @@ def compute_dr_pred(img, mode):
         current image
     mode : str
         current mode
+    num : list
+        side length of quadratic off region
 
     Returns
     -------
@@ -461,31 +482,31 @@ def compute_dr_pred(img, mode):
         dynamic range for the predicted image
     """
     if mode == "rms1":
-        rms = rms_comp(img, "rms1")
+        rms = rms_comp(img, "rms1", num)
 
     elif mode == "rms2":
-        rms = rms_comp(img, "rms2")
+        rms = rms_comp(img, "rms2", num)
 
     elif mode == "rms3":
-        rms = rms_comp(img, "rms3")
+        rms = rms_comp(img, "rms3", num)
 
     elif mode == "rms4":
-        rms = rms_comp(img, "rms4")
+        rms = rms_comp(img, "rms4", num)
 
     elif mode == "rms1+4":
-        rms = rms_comp(img, "rms1+4")
+        rms = rms_comp(img, "rms1+4", num)
 
     elif mode == "rms2+3":
-        rms = rms_comp(img, "rms2+3")
+        rms = rms_comp(img, "rms2+3", num)
 
     elif mode is None:
-        rms = rms_comp(img, None)
+        rms = rms_comp(img, None, num)
 
     dynamic_range = img.max() / rms
     return dynamic_range
 
 
-def rms_comp(img, mode):
+def rms_comp(img, mode, num):
     """Calls compute_rms according to the mode for the remaining corners
     with the right size.
 
@@ -495,52 +516,55 @@ def rms_comp(img, mode):
         current image
     mode : str
         current mode
+    num : list
+        side length of quadratic off region
 
     Returns
     -------
     rms
         combined RMS value for the given image
     """
+    num_three, num_two, num_four = num[0], num[1], num[2]
     rms = []
     if mode == "rms1":
-        rms.extend([compute_rms(img, "rms2", 13)])
-        rms.extend([compute_rms(img, "rms3", 13)])
-        rms.extend([compute_rms(img, "rms4", 13)])
+        rms.extend([compute_rms(img, "rms2", num_three)])
+        rms.extend([compute_rms(img, "rms3", num_three)])
+        rms.extend([compute_rms(img, "rms4", num_three)])
         rms = combine_rms(rms)
 
     elif mode == "rms2":
-        rms.extend([compute_rms(img, "rms1", 13)])
-        rms.extend([compute_rms(img, "rms3", 13)])
-        rms.extend([compute_rms(img, "rms4", 13)])
+        rms.extend([compute_rms(img, "rms1", num_three)])
+        rms.extend([compute_rms(img, "rms3", num_three)])
+        rms.extend([compute_rms(img, "rms4", num_three)])
         rms = combine_rms(rms)
 
     elif mode == "rms3":
-        rms.extend([compute_rms(img, "rms1", 13)])
-        rms.extend([compute_rms(img, "rms2", 13)])
-        rms.extend([compute_rms(img, "rms4", 13)])
+        rms.extend([compute_rms(img, "rms1", num_three)])
+        rms.extend([compute_rms(img, "rms2", num_three)])
+        rms.extend([compute_rms(img, "rms4", num_three)])
         rms = combine_rms(rms)
 
     elif mode == "rms4":
-        rms.extend([compute_rms(img, "rms1", 13)])
-        rms.extend([compute_rms(img, "rms2", 13)])
-        rms.extend([compute_rms(img, "rms3", 13)])
+        rms.extend([compute_rms(img, "rms1", num_three)])
+        rms.extend([compute_rms(img, "rms2", num_three)])
+        rms.extend([compute_rms(img, "rms3", num_three)])
         rms = combine_rms(rms)
 
     elif mode == "rms1+4":
-        rms.extend([compute_rms(img, "rms2", 20)])
-        rms.extend([compute_rms(img, "rms3", 20)])
+        rms.extend([compute_rms(img, "rms2", num_two)])
+        rms.extend([compute_rms(img, "rms3", num_two)])
         rms = combine_rms(rms)
 
     elif mode == "rms2+3":
-        rms.extend([compute_rms(img, "rms1", 20)])
-        rms.extend([compute_rms(img, "rms4", 20)])
+        rms.extend([compute_rms(img, "rms1", num_two)])
+        rms.extend([compute_rms(img, "rms4", num_two)])
         rms = combine_rms(rms)
 
     elif mode is None:
-        rms.extend([compute_rms(img, "rms1", 10)])
-        rms.extend([compute_rms(img, "rms2", 10)])
-        rms.extend([compute_rms(img, "rms3", 10)])
-        rms.extend([compute_rms(img, "rms4", 10)])
+        rms.extend([compute_rms(img, "rms1", num_four)])
+        rms.extend([compute_rms(img, "rms2", num_four)])
+        rms.extend([compute_rms(img, "rms3", num_four)])
+        rms.extend([compute_rms(img, "rms4", num_four)])
         rms = combine_rms(rms)
     assert rms.dtype == np.float64
     return rms

--- a/gaussian_sources/inspection.py
+++ b/gaussian_sources/inspection.py
@@ -206,26 +206,26 @@ def visualize_with_fourier(i, img_input, img_pred, img_truth, amp_phase, out_pat
     fig, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(2, 3, figsize=(16, 10))
 
     im1 = ax1.imshow(inp_real, cmap="RdBu")
-    make_axes_nice(fig, ax1, im1, r"Real Input")
+    make_axes_nice(fig, ax1, im1, r"Amplitude Input")
 
     im2 = ax2.imshow(
         real_pred, cmap="RdBu", vmin=real_truth.min(), vmax=real_truth.max()
     )
-    make_axes_nice(fig, ax2, im2, r"Real Prediction")
+    make_axes_nice(fig, ax2, im2, r"Amplitude Prediction")
 
     im3 = ax3.imshow(real_truth, cmap="RdBu")
-    make_axes_nice(fig, ax3, im3, r"Real Truth")
+    make_axes_nice(fig, ax3, im3, r"Amplitude Truth")
 
     im4 = ax4.imshow(inp_imag, cmap="RdBu")
-    make_axes_nice(fig, ax4, im4, r"Imaginary Input")
+    make_axes_nice(fig, ax4, im4, r"Phase Input")
 
     im5 = ax5.imshow(
         imag_pred, cmap="RdBu", vmin=imag_truth.min(), vmax=imag_truth.max()
     )
-    make_axes_nice(fig, ax5, im5, r"Imaginary Prediction")
+    make_axes_nice(fig, ax5, im5, r"Phase Prediction")
 
     im6 = ax6.imshow(imag_truth, cmap="RdBu")
-    make_axes_nice(fig, ax6, im6, r"Imaginary Truth")
+    make_axes_nice(fig, ax6, im6, r"Phase Truth")
 
     outpath = str(out_path) + "prediction_{}.png".format(i)
     fig.savefig(outpath, bbox_inches="tight", pad_inches=0.01)

--- a/gaussian_sources/inspection.py
+++ b/gaussian_sources/inspection.py
@@ -362,38 +362,179 @@ def plot_off_regions(ax, mode, img_size, num):
     """
     num_three, num_two, num_four = num[0], num[1], num[2]
     if mode == "rms1":
-        ax.axvspan(0, num_three-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(img_size-num_three, img_size-1, ymin=1 - num_three / img_size, ymax=0.99, color="red", fill=False)
-        ax.axvspan(img_size-num_three, img_size-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False)
+        ax.axvspan(
+            0,
+            num_three - 1,
+            ymax=num_three / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+            label="Off",
+        )
+        ax.axvspan(
+            img_size - num_three,
+            img_size - 1,
+            ymin=1 - num_three / img_size,
+            ymax=0.99,
+            color="red",
+            fill=False,
+        )
+        ax.axvspan(
+            img_size - num_three,
+            img_size - 1,
+            ymax=num_three / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+        )
     elif mode == "rms2":
-        ax.axvspan(0, num_three-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(0, num_three-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
-        ax.axvspan(img_size-num_three, img_size-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False)
+        ax.axvspan(
+            0,
+            num_three - 1,
+            ymax=num_three / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+            label="Off",
+        )
+        ax.axvspan(
+            0,
+            num_three - 1,
+            ymax=1 - num_three / img_size,
+            ymin=0.99,
+            color="red",
+            fill=False,
+        )
+        ax.axvspan(
+            img_size - num_three,
+            img_size - 1,
+            ymax=num_three / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+        )
     elif mode == "rms3":
         ax.axvspan(
-            0, num_three-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False, label="Off"
+            0,
+            num_three - 1,
+            ymax=1 - num_three / img_size,
+            ymin=0.99,
+            color="red",
+            fill=False,
+            label="Off",
         )
-        ax.axvspan(img_size-num_three, img_size-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
-        ax.axvspan(img_size-num_three, img_size-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False)
+        ax.axvspan(
+            img_size - num_three,
+            img_size - 1,
+            ymax=1 - num_three / img_size,
+            ymin=0.99,
+            color="red",
+            fill=False,
+        )
+        ax.axvspan(
+            img_size - num_three,
+            img_size - 1,
+            ymax=num_three / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+        )
     elif mode == "rms4":
-        ax.axvspan(0, num_three-1, ymax=num_three / img_size, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(0, num_three-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
-        ax.axvspan(img_size-num_three, img_size-1, ymax=1 - num_three / img_size, ymin=0.99, color="red", fill=False)
+        ax.axvspan(
+            0,
+            num_three - 1,
+            ymax=num_three / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+            label="Off",
+        )
+        ax.axvspan(
+            0,
+            num_three - 1,
+            ymax=1 - num_three / img_size,
+            ymin=0.99,
+            color="red",
+            fill=False,
+        )
+        ax.axvspan(
+            img_size - num_three,
+            img_size - 1,
+            ymax=1 - num_three / img_size,
+            ymin=0.99,
+            color="red",
+            fill=False,
+        )
     elif mode == "rms1+4":
-        ax.axvspan(0, num_two-1, ymax=num_two / img_size, ymin=0.01, color="red", fill=False, label="Off")
-        ax.axvspan(img_size-num_two, img_size-1, ymax=1 - num_two / img_size, ymin=0.99, color="red", fill=False)
+        ax.axvspan(
+            0,
+            num_two - 1,
+            ymax=num_two / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+            label="Off",
+        )
+        ax.axvspan(
+            img_size - num_two,
+            img_size - 1,
+            ymax=1 - num_two / img_size,
+            ymin=0.99,
+            color="red",
+            fill=False,
+        )
     elif mode == "rms2+3":
         ax.axvspan(
-            0, num_two-1, ymax=1 - num_two / img_size, ymin=0.99, color="red", fill=False, label="Off"
+            0,
+            num_two - 1,
+            ymax=1 - num_two / img_size,
+            ymin=0.99,
+            color="red",
+            fill=False,
+            label="Off",
         )
-        ax.axvspan(img_size-num_two, img_size-1, ymax=num_two / img_size, ymin=0.01, color="red", fill=False)
+        ax.axvspan(
+            img_size - num_two,
+            img_size - 1,
+            ymax=num_two / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+        )
     elif mode is None:
         ax.axvspan(
-            0, num_four-1, ymin=1 - num_four / img_size, ymax=0.99, color="red", fill=False, label="Off"
+            0,
+            num_four - 1,
+            ymin=1 - num_four / img_size,
+            ymax=0.99,
+            color="red",
+            fill=False,
+            label="Off",
         )
-        ax.axvspan(0, num_four-1, ymax=num_four / img_size, ymin=0.01, color="red", fill=False)
-        ax.axvspan(img_size-num_four, img_size-1, ymin=1 - num_four / img_size, ymax=0.99, color="red", fill=False)
-        ax.axvspan(img_size-num_four, img_size-1, ymax=num_four / img_size, ymin=0.01, color="red", fill=False)
+        ax.axvspan(
+            0,
+            num_four - 1,
+            ymax=num_four / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+        )
+        ax.axvspan(
+            img_size - num_four,
+            img_size - 1,
+            ymin=1 - num_four / img_size,
+            ymax=0.99,
+            color="red",
+            fill=False,
+        )
+        ax.axvspan(
+            img_size - num_four,
+            img_size - 1,
+            ymax=num_four / img_size,
+            ymin=0.01,
+            color="red",
+            fill=False,
+        )
 
 
 def compute_dr(i, img, sensitivity, num):

--- a/gaussian_sources/visualize/Makefile
+++ b/gaussian_sources/visualize/Makefile
@@ -11,7 +11,7 @@ build/visualize_predictions_done:
 	python visualize_predictions.py \
 	${out_path} \
 	-fourier ${fourier} -amp_phase ${amp_phase} -diff ${diff} \
-	-blob ${blob} ${mode}
+	-sensitivity ${sensitivity} -blob ${blob} ${mode}
 
 ./pred_save:
 	mkdir -p ${out_path}

--- a/gaussian_sources/visualize/visualize_predictions.py
+++ b/gaussian_sources/visualize/visualize_predictions.py
@@ -19,6 +19,7 @@ from gaussian_sources.inspection import (
 @click.option("-fourier", type=bool, required=True)
 @click.option("-amp_phase", type=bool, required=True)
 @click.option("-diff", type=bool, required=False)
+@click.option("-sensitivity", type=float, required=False)
 @click.option("-blob", type=bool, required=False)
 @click.option("-log", type=bool, required=False)
 @click.option("-index", type=int, required=False)
@@ -28,6 +29,7 @@ def main(
     fourier,
     amp_phase,
     diff=False,
+    sensitivity=1e-6,
     blob=False,
     index=None,
     log=False,
@@ -76,7 +78,9 @@ def main(
                 )
 
                 if diff:
-                    dynamic_range = plot_difference(i, ifft_pred, ifft_truth, out_path)
+                    dynamic_range = plot_difference(
+                        i, ifft_pred, ifft_truth, sensitivity, out_path
+                    )
                     dynamic_ranges.append(dynamic_range)
 
                 if blob:
@@ -90,6 +94,7 @@ def main(
                         i,
                         img_pred.reshape(64, 64),
                         img_truth.reshape(64, 64),
+                        sensitivity,
                         out_path,
                     )
                     dynamic_ranges.append(dynamic_range)
@@ -117,7 +122,7 @@ def main(
             )
             if diff:
                 dynamic_range = plot_difference(
-                    i, ifft_pred, ifft_truth, out_path
+                    i, ifft_pred, ifft_truth, sensitivity, out_path
                 )
                 dynamic_ranges.append(dynamic_range)
             if blob:
@@ -128,7 +133,9 @@ def main(
             )
 
             if diff:
-                dynamic_range = plot_difference(i, img_pred, img_truth, out_path)
+                dynamic_range = plot_difference(
+                    i, img_pred, img_truth, sensitivity, out_path
+                )
                 dynamic_ranges.append(dynamic_range)
             if blob:
                 blob_detection(i, img_pred, img_truth, out_path)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='radionets',
-    version='0.0.2',
+    version='0.0.4',
     description='Imaging radio interferometric data with neural networks',
     url='https://github.com/Kevin2/radionets',
     author='Kevin Schmidt, Felix Geyer',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'numpy==1.17.3',
         'astropy==3.2.3',
         'tqdm==4.36.1',
-        'click==7.0',
+        'click==7.1.2',
         'geos',
         'shapely==1.6.4',
         'proj',

--- a/tests/test_visualization/test_eval_plots.py
+++ b/tests/test_visualization/test_eval_plots.py
@@ -120,9 +120,9 @@ def test_plot_difference():
         test_ds[0][1].numpy(),
         test_ds[1][1].numpy(),
     )
-    dr_fourier = plot_difference(0, ifft_pred, ifft_truth, build)
+    dr_fourier = plot_difference(0, ifft_pred, ifft_truth, 1e-6, build)
     dr_wo_fourier = plot_difference(
-        0, img_pred.reshape(63, 63), img_truth.reshape(63, 63), build
+        0, img_pred.reshape(63, 63), img_truth.reshape(63, 63), 1e-6, build
     )
 
     assert dr_fourier.dtype == float


### PR DESCRIPTION
- Created upper limit for RMS values in the corners. If that limit is exceeded, this region is excluded from the computation and the other regions get larger by a third or a half, whether one or two regions are excluded.
- limit can be set via makerc (standard is 1e-6.)
- created mutliple new functions fore more modularity
- changes in computation are also plotted
- changed test accordingly
- changed click version because of this error message
- added different diff plotting for 127x127 pixel images
- made size of quadratic off regions more modular for easier changing

> ERROR: proj 0.2.0 has requirement click>=7.1.2, but you'll have click 7.0 which is incompatible.