### PR TITLE
Add variabel images size for filter_deep architecture

### DIFF
--- a/dl_framework/architectures.py
+++ b/dl_framework/architectures.py
@@ -525,7 +525,7 @@ class filter(nn.Module):
 
 
 class filter_deep(nn.Module):
-    def __init__(self):
+    def __init__(self, img_size):
         super().__init__()
         self.conv1_amp = nn.Sequential(
             *conv_amp(1, 4, (23, 23), 1, 11, 1)
@@ -546,12 +546,12 @@ class filter_deep(nn.Module):
              *conv_phase(8, 12, (17, 17), 1, 8, 1, add=1-pi)
         )
         self.conv_con1_amp = nn.Sequential(
-            LocallyConnected2d(12, 1, 127, 1, stride=1, bias=False),
+            LocallyConnected2d(12, 1, img_size, 1, stride=1, bias=False),
             nn.BatchNorm2d(1),
             nn.ReLU(),
         )
         self.conv_con1_phase = nn.Sequential(
-            LocallyConnected2d(12, 1, 127, 1, stride=1, bias=False),
+            LocallyConnected2d(12, 1, img_size, 1, stride=1, bias=False),
             nn.BatchNorm2d(1),
             GeneralELU(1-pi),
         )
@@ -581,12 +581,12 @@ class filter_deep(nn.Module):
              *conv_phase(12, 16, (3, 3), 1, 1, 1, add=1-pi)
         )
         self.conv_con2_amp = nn.Sequential(
-            LocallyConnected2d(16, 1, 127, 1, stride=1, bias=False),
+            LocallyConnected2d(16, 1, img_size, 1, stride=1, bias=False),
             nn.BatchNorm2d(1),
             nn.ReLU(),
         )
         self.conv_con2_phase = nn.Sequential(
-            LocallyConnected2d(16, 1, 127, 1, stride=1, bias=False),
+            LocallyConnected2d(16, 1, img_size, 1, stride=1, bias=False),
             nn.BatchNorm2d(1),
             GeneralELU(1-pi),
         )
@@ -616,12 +616,12 @@ class filter_deep(nn.Module):
              *conv_phase(12, 20, (3, 3), 1, 1, 1, add=1-pi)
         )
         self.conv_con3_amp = nn.Sequential(
-            LocallyConnected2d(20, 1, 127, 1, stride=1, bias=False),
+            LocallyConnected2d(20, 1, img_size, 1, stride=1, bias=False),
             nn.BatchNorm2d(1),
             nn.ReLU(),
         )
         self.conv_con3_phase = nn.Sequential(
-            LocallyConnected2d(20, 1, 127, 1, stride=1, bias=False),
+            LocallyConnected2d(20, 1, img_size, 1, stride=1, bias=False),
             nn.BatchNorm2d(1),
             GeneralELU(1-pi),
         )

--- a/gaussian_sources/train_cnn.py
+++ b/gaussian_sources/train_cnn.py
@@ -87,8 +87,12 @@ def main(
     bs = batch_size
     data = DataBunch(*get_dls(train_ds, valid_ds, bs))
 
+    img_size = train_ds[0][0][0].shape[1]
     # Define model
-    arch = getattr(architecture, arch)()
+    if arch == "filter_deep":
+        arch = getattr(architecture, arch)(img_size)
+    else:
+        arch = getattr(architecture, arch)()
 
     # make normalisation
     norm = normalize_tfm(norm_path)


### PR DESCRIPTION
- added `img_size` for the `filter_deep` architecture
- added `img_size` to `getattr` for the calling of `filter_deep` in `train_cnn.py`

now one can train with `filter_deep` without worrying about the image size.