### PR TITLE
Add functionalities for 511 pixel pictures

### DIFF
--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -64,7 +64,7 @@ class h5_dataset:
         return x, y
 
     def open_bundle(self, bundle_path, var):
-        bundle = np.load(bundle_path)
+        bundle = np.load(bundle_path, mmap_mode="r")
         data = bundle[var]
         return data
 
@@ -81,7 +81,6 @@ class h5_dataset:
             np.load(self.bundles[bundle], mmap_mode='r') for bundle in bundle_unique
         ]
         bundle_paths_str = list(map(str, bundle_paths))
-        print("image", image)
         for bund in bundle_paths_str:
             print("bundle paths str: ", bundle_paths_str)
             print("bundle paths: ", bundle_paths)

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -203,6 +203,16 @@ def open_fft_pair(path):
     return bundle_x, bundle_y
 
 
+def open_fft_pair_npz(path):
+    """
+    open fft_pairs for files saved in .npz format
+    """
+    f = np.load(path)
+    bundle_x = np.array(f["x"])
+    bundle_y = np.array(f["y"])
+    return bundle_x, bundle_y
+
+
 def mean_and_std(array):
     return array.mean(), array.std()
 

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -64,6 +64,7 @@ class h5_dataset:
         return x, y
 
     def open_bundle(self, bundle_path, var):
+        # distinguish between compressed (npz) or not compressed (h5)
         if re.search(".npz", str(bundle_path)):
             bundle = np.load(bundle_path, mmap_mode="r")
         else:
@@ -80,6 +81,7 @@ class h5_dataset:
         bundle = indices // self.num_img
         image = indices - bundle * self.num_img
         bundle_unique = torch.unique(bundle)
+        # distinguish between compressed (npz) or not compressed (h5)
         if re.search(".npz", str(self.bundles[bundle])):
             bundle_paths = [
                 np.load(self.bundles[bundle], mmap_mode='r') for bundle in bundle_unique

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -64,7 +64,10 @@ class h5_dataset:
         return x, y
 
     def open_bundle(self, bundle_path, var):
-        bundle = np.load(bundle_path, mmap_mode="r")
+        if re.search(".npz", str(bundle_path)):
+            bundle = np.load(bundle_path, mmap_mode="r")
+        else:
+            bundle = h5py.File(bundle_path, "r")
         data = bundle[var]
         return data
 
@@ -77,19 +80,24 @@ class h5_dataset:
         bundle = indices // self.num_img
         image = indices - bundle * self.num_img
         bundle_unique = torch.unique(bundle)
-        bundle_paths = [
-            np.load(self.bundles[bundle], mmap_mode='r') for bundle in bundle_unique
-        ]
+        if re.search(".npz", str(self.bundles[bundle])):
+            bundle_paths = [
+                np.load(self.bundles[bundle], mmap_mode='r') for bundle in bundle_unique
+            ]
+        else:
+            bundle_paths = [
+                h5py.File(self.bundles[bundle], 'r') for bundle in bundle_unique
+            ]
         bundle_paths_str = list(map(str, bundle_paths))
-        for bund in bundle_paths_str:
-            print("bundle paths str: ", bundle_paths_str)
-            print("bundle paths: ", bundle_paths)
-            print("bund: ", bund)
-            # if False in (bundle == bundle_unique[bundle_paths.index(bund)]).numpy():
-            #     print("jo")
-            print("bundle path index: ", bundle_paths_str.index(str(bund)))
-            # print("Maske: ", bundle == bundle_unique[bundle_paths.index(bund)])
-            # print("image bundle geschichte: ", image[bundle == bundle_unique[bundle_paths.index(bund)]])
+        # for bund in bundle_paths_str:
+        #     print("bundle paths str: ", bundle_paths_str)
+        #     print("bundle paths: ", bundle_paths)
+        #     print("bund: ", bund)
+        #     # if False in (bundle == bundle_unique[bundle_paths.index(bund)]).numpy():
+        #     #     print("jo")
+        #     print("bundle path index: ", bundle_paths_str.index(str(bund)))
+        #     # print("Maske: ", bundle == bundle_unique[bundle_paths.index(bund)])
+        #     # print("image bundle geschichte: ", image[bundle == bundle_unique[bundle_paths.index(bund)]])
         data = torch.tensor(
             [
                 bund[var][img]

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -82,7 +82,7 @@ class h5_dataset:
         image = indices - bundle * self.num_img
         bundle_unique = torch.unique(bundle)
         # distinguish between compressed (npz) or not compressed (h5)
-        if re.search(".npz", str(self.bundles[bundle])):
+        if re.search(".npz", str(self.bundles[bundle[0]])):
             bundle_paths = [
                 np.load(self.bundles[bundle], mmap_mode='r') for bundle in bundle_unique
             ]

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -78,23 +78,24 @@ class h5_dataset:
         image = indices - bundle * self.num_img
         bundle_unique = torch.unique(bundle)
         bundle_paths = [
-            np.load(self.bundles[bundle]) for bundle in bundle_unique
+            np.load(self.bundles[bundle], mmap_mode='r') for bundle in bundle_unique
         ]
-        print("bundle_unique: ", bundle_unique)
+        bundle_paths_str = list(map(str, bundle_paths))
         print("image", image)
-        for bund in bundle_paths:
-            print("bund: ", bund)
+        for bund in bundle_paths_str:
+            print("bundle paths str: ", bundle_paths_str)
             print("bundle paths: ", bundle_paths)
+            print("bund: ", bund)
             # if False in (bundle == bundle_unique[bundle_paths.index(bund)]).numpy():
             #     print("jo")
-            print("bundle path index: ", bundle_paths.index(bund))
+            print("bundle path index: ", bundle_paths_str.index(str(bund)))
             # print("Maske: ", bundle == bundle_unique[bundle_paths.index(bund)])
             # print("image bundle geschichte: ", image[bundle == bundle_unique[bundle_paths.index(bund)]])
         data = torch.tensor(
             [
                 bund[var][img]
-                for bund in bundle_paths
-                for img in image[bundle == bundle_unique[bundle_paths.index(bund)]]
+                for bund, bund_str in zip(bundle_paths, bundle_paths_str)
+                for img in image[bundle == bundle_unique[bundle_paths_str.index(bund_str)]]
             ]
         )
         if var == "x" or self.tar_fourier is True:

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -91,15 +91,6 @@ class h5_dataset:
                 h5py.File(self.bundles[bundle], 'r') for bundle in bundle_unique
             ]
         bundle_paths_str = list(map(str, bundle_paths))
-        # for bund in bundle_paths_str:
-        #     print("bundle paths str: ", bundle_paths_str)
-        #     print("bundle paths: ", bundle_paths)
-        #     print("bund: ", bund)
-        #     # if False in (bundle == bundle_unique[bundle_paths.index(bund)]).numpy():
-        #     #     print("jo")
-        #     print("bundle path index: ", bundle_paths_str.index(str(bund)))
-        #     # print("Maske: ", bundle == bundle_unique[bundle_paths.index(bund)])
-        #     # print("image bundle geschichte: ", image[bundle == bundle_unique[bundle_paths.index(bund)]])
         data = torch.tensor(
             [
                 bund[var][img]

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -80,6 +80,16 @@ class h5_dataset:
         bundle_paths = [
             np.load(self.bundles[bundle]) for bundle in bundle_unique
         ]
+        print("bundle_unique: ", bundle_unique)
+        print("image", image)
+        for bund in bundle_paths:
+            print("bund: ", bund)
+            print("bundle paths: ", bundle_paths)
+            # if False in (bundle == bundle_unique[bundle_paths.index(bund)]).numpy():
+            #     print("jo")
+            print("bundle path index: ", bundle_paths.index(bund))
+            # print("Maske: ", bundle == bundle_unique[bundle_paths.index(bund)])
+            # print("image bundle geschichte: ", image[bundle == bundle_unique[bundle_paths.index(bund)]])
         data = torch.tensor(
             [
                 bund[var][img]

--- a/dl_framework/data.py
+++ b/dl_framework/data.py
@@ -64,7 +64,7 @@ class h5_dataset:
         return x, y
 
     def open_bundle(self, bundle_path, var):
-        bundle = h5py.File(bundle_path, "r")
+        bundle = np.load(bundle_path)
         data = bundle[var]
         return data
 
@@ -78,7 +78,7 @@ class h5_dataset:
         image = indices - bundle * self.num_img
         bundle_unique = torch.unique(bundle)
         bundle_paths = [
-            h5py.File(self.bundles[bundle], "r") for bundle in bundle_unique
+            np.load(self.bundles[bundle]) for bundle in bundle_unique
         ]
         data = torch.tensor(
             [

--- a/gaussian_sources/Makefile
+++ b/gaussian_sources/Makefile
@@ -1,7 +1,7 @@
 -include .makerc
 dataset: simulate_bundles\
 		 fft_samp\
-		#  calc_normalization
+		 calc_normalization
 
 simulate_bundles: ${data}/gaussian_sources_train0.h5
 

--- a/gaussian_sources/Makefile
+++ b/gaussian_sources/Makefile
@@ -27,6 +27,7 @@ ${data}/fft_samp_train0.h5:
 		-noise ${noise} \
 		-preview ${preview} \
 		-specific_mask False \
+		-compressed True\
 		-lon -80 \
 		-lat 50 \
 		-steps 50

--- a/gaussian_sources/Makefile
+++ b/gaussian_sources/Makefile
@@ -1,7 +1,7 @@
 -include .makerc
 dataset: simulate_bundles\
 		 fft_samp\
-		 calc_normalization
+		#  calc_normalization
 
 simulate_bundles: ${data}/gaussian_sources_train0.h5
 

--- a/gaussian_sources/Makefile
+++ b/gaussian_sources/Makefile
@@ -26,7 +26,7 @@ ${data}/fft_samp_train0.h5:
 		-amp_phase ${amp_phase} \
 		-noise ${noise} \
 		-preview ${preview} \
-		-specific_mask True \
+		-specific_mask False \
 		-lon -80 \
 		-lat 50 \
 		-steps 50

--- a/gaussian_sources/calculate_normalization.py
+++ b/gaussian_sources/calculate_normalization.py
@@ -1,5 +1,5 @@
 import click
-from dl_framework.data import open_fft_pair, get_bundles, mean_and_std
+from dl_framework.data import open_fft_pair_npz, get_bundles, mean_and_std
 import pandas as pd
 import numpy as np
 import re
@@ -21,7 +21,7 @@ def main(data_path, out_path):
     stds_imag = np.array([])
 
     for path in tqdm(bundle_paths):
-        x, _ = open_fft_pair(path)
+        x, _ = open_fft_pair_npz(path)
         x_amp, x_imag = np.double(x[:, 0]), np.double(x[:, 1])
         mean_amp, std_amp = mean_and_std(x_amp)
         mean_imag, std_imag = mean_and_std(x_imag)

--- a/gaussian_sources/calculate_normalization.py
+++ b/gaussian_sources/calculate_normalization.py
@@ -1,5 +1,10 @@
 import click
-from dl_framework.data import open_fft_pair_npz, get_bundles, mean_and_std
+from dl_framework.data import (
+    open_fft_pair_npz,
+    open_fft_pair,
+    get_bundles,
+    mean_and_std,
+)
 import pandas as pd
 import numpy as np
 import re
@@ -21,7 +26,10 @@ def main(data_path, out_path):
     stds_imag = np.array([])
 
     for path in tqdm(bundle_paths):
-        x, _ = open_fft_pair_npz(path)
+        if re.search(".npz", str(path)):
+            x, _ = open_fft_pair_npz(path)
+        else:
+            x, _ = open_fft_pair(path)
         x_amp, x_imag = np.double(x[:, 0]), np.double(x[:, 1])
         mean_amp, std_amp = mean_and_std(x_amp)
         mean_imag, std_imag = mean_and_std(x_imag)
@@ -38,8 +46,8 @@ def main(data_path, out_path):
     d = {
         "train_mean_c0": [mean_amp],
         "train_std_c0": [std_amp],
-        'train_mean_c1': [mean_imag],
-        'train_std_c1': [std_imag]
+        "train_mean_c1": [mean_imag],
+        "train_std_c1": [std_imag],
     }
 
     df = pd.DataFrame(data=d)

--- a/gaussian_sources/calculate_normalization.py
+++ b/gaussian_sources/calculate_normalization.py
@@ -26,6 +26,7 @@ def main(data_path, out_path):
     stds_imag = np.array([])
 
     for path in tqdm(bundle_paths):
+        # distinguish between compressed (.npz) and not compressed (.h5) files
         if re.search(".npz", str(path)):
             x, _ = open_fft_pair_npz(path)
         else:

--- a/gaussian_sources/create_fft_pairs.py
+++ b/gaussian_sources/create_fft_pairs.py
@@ -109,8 +109,8 @@ def main(
                 # with open(out, 'wb') as f:
                 #     np.save(f, bundle_samp)
                 #     np.save(f, bundle_fft)
-                savez_compressed(out, x=bundle_samp, y=bundle_fft)
-                # save_fft_pair(out, bundle_samp, bundle_fft)
+                # savez_compressed(out, x=bundle_samp, y=bundle_fft)
+                save_fft_pair(out, bundle_samp, bundle_fft)
             else:
                 save_fft_pair(out, bundle_samp, images)
 

--- a/gaussian_sources/create_fft_pairs.py
+++ b/gaussian_sources/create_fft_pairs.py
@@ -22,6 +22,7 @@ from numpy import savez_compressed
 @click.option("-amp_phase", type=bool, required=True)
 @click.option("-fourier", type=bool, required=True)
 @click.option("-specific_mask", type=bool)
+@click.option("-compressed", type=bool)
 @click.option("-lon", type=float, required=False)
 @click.option("-lat", type=float, required=False)
 @click.option("-steps", type=float, required=False)
@@ -33,6 +34,7 @@ def main(
     antenna_config_path,
     amp_phase,
     fourier,
+    compressed=False,
     specific_mask=False,
     lon=None,
     lat=None,
@@ -107,14 +109,13 @@ def main(
                 )
             out = out_path + path.name.split("_")[-1]
             if fourier:
-                # with open(out, 'wb') as f:
-                #     np.save(f, bundle_samp)
-                #     np.save(f, bundle_fft)
-                # savez_compressed(out, x=bundle_samp, y=bundle_fft)
-                save_fft_pair(out, bundle_samp, bundle_fft)
+                if compressed:
+                    savez_compressed(out, x=bundle_samp, y=bundle_fft)
+                    os.remove(path)
+                else:
+                    save_fft_pair(out, bundle_samp, bundle_fft)
             else:
                 save_fft_pair(out, bundle_samp, images)
-            # os.remove(path)
 
 
 if __name__ == "__main__":

--- a/gaussian_sources/create_fft_pairs.py
+++ b/gaussian_sources/create_fft_pairs.py
@@ -110,11 +110,11 @@ def main(
                 # with open(out, 'wb') as f:
                 #     np.save(f, bundle_samp)
                 #     np.save(f, bundle_fft)
-                savez_compressed(out, x=bundle_samp, y=bundle_fft)
-                # save_fft_pair(out, bundle_samp, bundle_fft)
+                # savez_compressed(out, x=bundle_samp, y=bundle_fft)
+                save_fft_pair(out, bundle_samp, bundle_fft)
             else:
                 save_fft_pair(out, bundle_samp, images)
-            os.remove(path)
+            # os.remove(path)
 
 
 if __name__ == "__main__":

--- a/gaussian_sources/create_fft_pairs.py
+++ b/gaussian_sources/create_fft_pairs.py
@@ -11,6 +11,7 @@ from dl_framework.data import (
 from simulations.uv_simulations import sample_freqs
 from simulations.gaussian_simulations import add_noise
 import re
+from numpy import savez_compressed
 
 
 @click.command()
@@ -105,7 +106,11 @@ def main(
                 )
             out = out_path + path.name.split("_")[-1]
             if fourier:
-                save_fft_pair(out, bundle_samp, bundle_fft)
+                # with open(out, 'wb') as f:
+                #     np.save(f, bundle_samp)
+                #     np.save(f, bundle_fft)
+                savez_compressed(out, x=bundle_samp, y=bundle_fft)
+                # save_fft_pair(out, bundle_samp, bundle_fft)
             else:
                 save_fft_pair(out, bundle_samp, images)
 

--- a/gaussian_sources/create_fft_pairs.py
+++ b/gaussian_sources/create_fft_pairs.py
@@ -1,4 +1,5 @@
 import click
+import os
 import numpy as np
 from tqdm import tqdm
 from dl_framework.data import (
@@ -109,10 +110,11 @@ def main(
                 # with open(out, 'wb') as f:
                 #     np.save(f, bundle_samp)
                 #     np.save(f, bundle_fft)
-                # savez_compressed(out, x=bundle_samp, y=bundle_fft)
-                save_fft_pair(out, bundle_samp, bundle_fft)
+                savez_compressed(out, x=bundle_samp, y=bundle_fft)
+                # save_fft_pair(out, bundle_samp, bundle_fft)
             else:
                 save_fft_pair(out, bundle_samp, images)
+            os.remove(path)
 
 
 if __name__ == "__main__":

--- a/gaussian_sources/create_fft_pairs.py
+++ b/gaussian_sources/create_fft_pairs.py
@@ -69,6 +69,11 @@ def main(
             if amp_phase:
                 amp, phase = split_amp_phase(bundle_fft)
                 amp = (np.log10(amp + 1e-10) / 10) + 1
+
+                # Test new masking for 511 Pixel pictures
+                if amp.shape[1] == 511:
+                    mask = amp > 0.1
+                    phase[~mask] = 0
                 bundle_fft = np.stack((amp, phase), axis=1)
             else:
                 real, imag = split_real_imag(bundle_fft)

--- a/gaussian_sources/inspection.py
+++ b/gaussian_sources/inspection.py
@@ -317,6 +317,11 @@ def plot_difference(i, img_pred, img_truth, sensitivity, out_path):
         num_three = 60
         num_two = 50
         num_four = 40
+    elif img_size == 511:
+        # work in progress, these are dummy values for compilating
+        num_three = 60
+        num_two = 50
+        num_four = 40
     num = [num_three, num_two, num_four]
     dr_truth, mode = compute_dr(i, img_truth, sensitivity, num)
     dr_pred = compute_dr_pred(img_pred, mode, num)

--- a/gaussian_sources/train_cnn.py
+++ b/gaussian_sources/train_cnn.py
@@ -89,7 +89,7 @@ def main(
 
     img_size = train_ds[0][0][0].shape[1]
     # Define model
-    if arch == "filter_deep":
+    if arch == "filter_deep" or arch == "filter_deep_amp" or arch == "filter_deep_phase":
         arch = getattr(architecture, arch)(img_size)
     else:
         arch = getattr(architecture, arch)()

--- a/simulations/gaussian_simulations.py
+++ b/simulations/gaussian_simulations.py
@@ -221,7 +221,7 @@ def gauss_paramters():
     while amp_start == 0:
         amp_start = (np.random.randint(0, 100) * np.random.random()) / 10
     # logarithmic decrease to outer components
-    amp = np.array([amp_start / np.exp(i) for i in range(comps)])
+    amp = np.array([amp_start / np.exp(i) * 5 for i in range(comps)])
 
     # linear distance bestween the components
     x = np.arange(0, comps) * 25
@@ -236,8 +236,8 @@ def gauss_paramters():
     off2 = (np.random.random() + 0.5) / 4
     fac1 = (np.random.random() + 1) / 4
     fac2 = (np.random.random() + 1) / 4
-    sig_x = (np.arange(1, comps + 1) - off1) * fac1 * 12
-    sig_y = (np.arange(1, comps + 1) - off2) * fac2 * 12
+    sig_x = (np.arange(1, comps + 1) - off1) * fac1 * 20
+    sig_y = (np.arange(1, comps + 1) - off2) * fac2 * 20
 
     # jet rotation
     rot = np.random.randint(0, 360)

--- a/simulations/gaussian_simulations.py
+++ b/simulations/gaussian_simulations.py
@@ -224,7 +224,7 @@ def gauss_paramters():
     amp = np.array([amp_start / np.exp(i) for i in range(comps)])
 
     # linear distance bestween the components
-    x = np.arange(0, comps) * 5
+    x = np.arange(0, comps) * 25
     y = np.zeros(comps)
 
     # extension of components
@@ -236,8 +236,8 @@ def gauss_paramters():
     off2 = (np.random.random() + 0.5) / 4
     fac1 = (np.random.random() + 1) / 4
     fac2 = (np.random.random() + 1) / 4
-    sig_x = (np.arange(1, comps + 1) - off1) * fac1
-    sig_y = (np.arange(1, comps + 1) - off2) * fac2
+    sig_x = (np.arange(1, comps + 1) - off1) * fac1 * 12
+    sig_y = (np.arange(1, comps + 1) - off2) * fac2 * 12
 
     # jet rotation
     rot = np.random.randint(0, 360)

--- a/simulations/gaussian_simulations.py
+++ b/simulations/gaussian_simulations.py
@@ -221,7 +221,7 @@ def gauss_paramters():
     while amp_start == 0:
         amp_start = (np.random.randint(0, 100) * np.random.random()) / 10
     # logarithmic decrease to outer components
-    amp = np.array([amp_start / np.exp(i) * 5 for i in range(comps)])
+    amp = np.array([amp_start / np.exp(i) for i in range(comps)])
 
     # linear distance bestween the components
     x = np.arange(0, comps) * 25

--- a/simulations/gaussian_simulations.py
+++ b/simulations/gaussian_simulations.py
@@ -224,7 +224,7 @@ def gauss_paramters():
     amp = np.array([amp_start / np.exp(i) for i in range(comps)])
 
     # linear distance bestween the components
-    x = np.arange(0, comps) * 25
+    x = np.arange(0, comps) * 5
     y = np.zeros(comps)
 
     # extension of components
@@ -236,8 +236,8 @@ def gauss_paramters():
     off2 = (np.random.random() + 0.5) / 4
     fac1 = (np.random.random() + 1) / 4
     fac2 = (np.random.random() + 1) / 4
-    sig_x = (np.arange(1, comps + 1) - off1) * fac1 * 20
-    sig_y = (np.arange(1, comps + 1) - off2) * fac2 * 20
+    sig_x = (np.arange(1, comps + 1) - off1) * fac1
+    sig_y = (np.arange(1, comps + 1) - off2) * fac2
 
     # jet rotation
     rot = np.random.randint(0, 360)


### PR DESCRIPTION
- added keyword _compressed_ for handling compressed saved files (with `savez_compressed` from `numpy`)
  - option in `h5_dataset` for loading compressed saved pictures
  - option in `calculate_normalization`
  - added compressed saving option in `create_fft_pairs` and masking for phase if 511 pixel pictures are used
- updated `filter_deep_amp` and `filter_deep_phase` with the new `img_size` argument